### PR TITLE
feat: improve key derivation debug and error reporting

### DIFF
--- a/src/reader.py
+++ b/src/reader.py
@@ -18,6 +18,7 @@ scripts that change their working directory.
 """
 
 import argparse
+import logging
 import os
 import re
 import shutil
@@ -176,6 +177,7 @@ def derive_keys(uid_hex: str, derive_py_abs: str) -> str:
     tmp = tempfile.NamedTemporaryFile(prefix="keys_", suffix=".dic", delete=False, mode="w")
     tmp.write(proc.stdout)
     tmp.close()
+    logging.debug("Chiavi derivate salvate in %s:\n%s", tmp.name, proc.stdout.strip())
     return tmp.name
 
 
@@ -187,16 +189,13 @@ def nfclassic_dump(out_mfd_abs: str, keys_dic_path: str) -> subprocess.Completed
     """
 
     proc = sh(["nfc-mfclassic", "r", "a", out_mfd_abs, keys_dic_path], check=False)
-    if proc.returncode != 0:
-        raise RuntimeError(
-            f"nfc-mfclassic failed ({proc.returncode})\n"
-            f"--- STDOUT ---\n{proc.stdout}\n--- STDERR ---\n{proc.stderr}"
-        )
+    out_combined = proc.stdout + proc.stderr
 
-    out_combined = (proc.stdout + proc.stderr).lower()
-    if "authentication failed" in out_combined:
+    if proc.returncode != 0 or "authentication failed" in out_combined.lower():
+        m = re.search(r"(sector|block)\s+([0-9A-Fa-fx]+)", out_combined, re.IGNORECASE)
+        where = f"{m.group(1)} {m.group(2)}" if m else "sconosciuto"
         raise RuntimeError(
-            "Autenticazione al tag fallita (chiavi errate?).\n"
+            f"Autenticazione al tag fallita su {where}.\n"
             f"--- STDOUT ---\n{proc.stdout}\n--- STDERR ---\n{proc.stderr}"
         )
 
@@ -259,7 +258,13 @@ def main() -> None:
         default=8.0,
         help="Secondi massimi per trovare l'UID con nfc-list (default: 8.0)",
     )
+    ap.add_argument("--debug", action="store_true", help="Abilita messaggi di debug")
     args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="[%(levelname)s] %(message)s",
+    )
 
     guide_path = Path(args.guide)
     derive_py_abs: str | None = None


### PR DESCRIPTION
## Summary
- log derived MIFARE keys for debugging
- expose block/sector when nfc-mfclassic fails
- add `--debug` flag to enable verbose output

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c7e4fb9c188323aab72683f71c2193