### PR TITLE
Import tempfile in reader

### DIFF
--- a/src/reader.py
+++ b/src/reader.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.request
 import zipfile


### PR DESCRIPTION
## Summary
- add missing `tempfile` import to reader script

## Testing
- `python src/reader.py --guide ./RFID-Tag-Guide` *(fails: [Errno 2] No such file or directory: 'nfc-list')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7fed0bd488323acd11ae71356cec1